### PR TITLE
Make test working with Python3

### DIFF
--- a/tests/test_bf.py
+++ b/tests/test_bf.py
@@ -1,4 +1,5 @@
 from array import array
+from base64 import b64encode
 import _pybloof
 
 
@@ -22,9 +23,9 @@ def test_long_pybloof():
     assert 1015 in dmc
     assert 2015 not in dmc
 
-    origin = dmc.to_byte_array().tostring().encode('hex')
+    origin = b64encode(dmc.to_byte_array().tostring())
     dmc_2 = _pybloof.LongBloomFilter.from_byte_array(dmc.to_byte_array())
-    clone = dmc_2.to_byte_array().tostring().encode('hex')
+    clone = b64encode(dmc_2.to_byte_array().tostring())
     assert origin == clone
 
     assert 1015 in dmc_2


### PR DESCRIPTION
We're using your project to run our Python3 project https://github.com/jstangle/shacol and we got an error while running tests.

Output ommited...
> test_probability.test_string_bf ... ok
> test_probability.test_long_bf ... ok
> test_probability.test_uint_bf ... ok
> 
> ======================================================================
> ERROR: test_bf.test_long_pybloof
> ----------------------------------------------------------------------
> Traceback (most recent call last):
>   File "/usr/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
>     self.test(*self.arg)
>   File "/home/ogajduse/Documents/repos/pybloof/tests/test_bf.py", line 25, in test_long_pybloof
>     origin = dmc.to_byte_array().tostring().encode('hex')
> AttributeError: 'bytes' object has no attribute 'encode'
> 
> ----------------------------------------------------------------------
> Ran 10 tests in 0.042s
> 
> FAILED (errors=1)

Reproducer of this bug:

    python3 setup.py test

Explanation [here](https://stackoverflow.com/a/16750574/6239929)

I've tested on Python2 and also Python3, both works with this patch.
I would be so grateful if this patch will take place also at PyPi in the shortest time.