### PR TITLE
Enable cythonized range contains

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ ext_modules = [
 
 setup(
     name='pybloof',
-    version='0.7.2',
+    version='0.7.3',
     author='Jake Heinz',
     author_email='me@jh.gg',
     url="http://github.com/jhgg/pybloof",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ ext_modules = [
 
 setup(
     name='pybloof',
-    version='0.7.1',
+    version='0.7.2',
     author='Jake Heinz',
     author_email='me@jh.gg',
     url="http://github.com/jhgg/pybloof",


### PR DESCRIPTION
The standard `contains` function in pybloof checks for a single element. If you'd like to check a range of elements, this is python-limited and slow, so this PR is for a cythonized "range contains".